### PR TITLE
fixed issue with multiple instances not working

### DIFF
--- a/NeoPixels.class.nut
+++ b/NeoPixels.class.nut
@@ -13,39 +13,32 @@ class NeoPixels {
 	// when instantiated, the neopixel class will fill this array with blobs to
 	// represent the waveforms to send the numbers 0 to 255. This allows the blobs to be
 	// copied in directly, instead of being built for each pixel - which makes the class faster.
-
 	bits            = null;
 
 	// Like bits, this blob holds the waveform to send the color [0,0,0], to clear pixels faster
-
-	clearblob       = blob(12);
+	clearblob       = null;
 
 	// private variables passed into the constructor
-
 	spi             = null; // imp SPI interface (pre-configured)
 	frameSize       = null; // number of pixels per frame
 	frame           = null; // a blob to hold the current frame
 
 	// _spi - A configured spi (MSB_FIRST, 7.5MHz)
 	// _frameSize - Number of Pixels per frame
-
 	constructor(_spi, _frameSize) {
-		this.spi = _spi;
-		this.frameSize = _frameSize;
-		this.frame = blob(frameSize*BYTESPERPIXEL + 1);
-		this.frame[frameSize*BYTESPERPIXEL] = 0;
+		spi = _spi;
+		frameSize = _frameSize;
+		frame = blob(frameSize*BYTESPERPIXEL + 1);
+		frame[frameSize*BYTESPERPIXEL] = 0;
 
 		// prepare the bits array and the clearblob blob
-
 		initialize();
-
 		clearFrame();
 		writeFrame();
 	}
 
 	// fill the array of representative 1-wire waveforms.
 	// done by the constructor at instantiation.
-
 	function initialize() {
 		// fill the bits array first
 
@@ -64,6 +57,7 @@ class NeoPixels {
 		}
 
 		// now fill the clearblob
+		clearblob = blob(BYTESPERPIXEL);
 		for(local j = 0; j < BYTESPERPIXEL; j++) {
 			clearblob.writen(ZERO, 'b');
 		}


### PR DESCRIPTION
clearblob was not scoped properly and was leaking

To test: 

``` Squirrel
spi1 <- hardware.spi189;
spi2 <- hardware.spi257;

spi1.configure(MSB_FIRST, 7500);
spi2.configure(MSB_FIRST, 7500);

neo1 <- NeoPixels(spi1, 2);
neo2 <- NeoPixels(spi2, 2);

neo1.writePixel(1, [0, 0, 255]);
neo2.writePixel(1, [255, 0, 0]);

local hexdump1 = "";
local hexdump2 = "";
for (local i = 0; i < neo1.frame.len(); i++) {
    hexdump1 += format("%02X ",neo1.frame[i]);
}
for (local i = 0; i < neo2.frame.len(); i++) {
    hexdump2 += format("%02X ",neo2.frame[i]);
}
```

server.log("Neopixel strip 1:");
server.log(hexdump1);
server.log("Neopixel strip 2:");
server.log(hexdump2);
