### PR TITLE
V2.0.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# WS2812 v2.0.1
+# WS2812 v2.0.2
 
 This class allows the imp to drive WS2812 and WS2812B LEDs. The WS2812 is an all-in-one RGB LED with integrated shift register and constant-current driver. The parts are daisy-chained, and a proprietary one-wire protocol is used to send data to the chain of LEDs. Each pixel is individually addressable and this allows the part to be used for a wide range of effects animations.
 
@@ -9,9 +9,9 @@ Some example hardware that uses the WS2812 or WS2812B:
 * [30 LED - 1m strip](http://www.adafruit.com/products/1376)
 * [NeoPixel Stick](http://www.adafruit.com/products/1426)
 
-**To add this library to your project, add `#require "WS2812.class.nut:2.0.1"` to the top of your device code.**
+**To add this library to your project, add `#require "WS2812.class.nut:2.0.2"` to the top of your device code.**
 
-You can view the library’s source code on [GitHub](https://github.com/electricimp/ws2812/tree/v2.0.1).
+You can view the library’s source code on [GitHub](https://github.com/electricimp/ws2812/tree/v2.0.2).
 
 ## Hardware
 
@@ -38,7 +38,7 @@ pixels
 Instantiate the class with a pre-configured SPI object and the number of pixels that are connected. The SPI object must be configured at 7500kHz and have the *MSB_FIRST* flag set:
 
 ```squirrel
-#require "ws2812.class.nut:2.0.1"
+#require "ws2812.class.nut:2.0.2"
 
 // Configure the SPI bus
 spi <- hardware.spi257;
@@ -59,7 +59,7 @@ Rather than pass a preconfigured SPI object to the constructor, you can pass an 
 **NOTE:** If you are using the *configure* method, you **must** pass `false` the the *draw* parameter of the constructor:
 
 ```squirrel
-#require "ws2812.class.nut:2.0.1"
+#require "ws2812.class.nut:2.0.2"
 
 // Create and configure an LED array with 5 pixels:
 pixels <- WS2812(hardware.spi257, 5, false).configure();

--- a/WS2812.class.nut
+++ b/WS2812.class.nut
@@ -7,7 +7,7 @@ class WS2812 {
     // This requires one byte per bit to send data at 7.5 MHz via SPI.
     // These consts define the "waveform" to represent a zero or one
 
-    static version = [2,0,1];
+    static VERSION = [2,0,2];
 
     static ZERO            = 0xC0;
     static ONE             = 0xF8;

--- a/WS2812.class.nut
+++ b/WS2812.class.nut
@@ -81,13 +81,12 @@ class WS2812 {
     //
     // NOTE: set(index, color) replaces v1.x.x's writePixel(p, color) method
     function set(index, color) {
-        assert(index >= 0 && index < _frameSize);
-        assert(color[0] >= 0 && color[0] <= 255);
-        assert(color[1] >= 0 && color[1] <= 255);
-        assert(color[2] >= 0 && color[2] <= 255);
+        index = _checkRange(index);
+        color = _checkColorRange(color);
 
         _frame.seek(index * BYTES_PER_PIXEL);
 
+        // Create a blob for the color
         // Red and green are swapped for some reason, so swizzle them back
         _frame.writeblob(_bits[color[1]]);
         _frame.writeblob(_bits[color[0]]);
@@ -95,7 +94,6 @@ class WS2812 {
 
         return this;
     }
-
 
     // Sets the frame buffer (or a portion of the frame buffer)
     // to the specified color, but does not write it to the pixel strip
@@ -107,11 +105,9 @@ class WS2812 {
         if (end == null) { end = _frameSize - 1; }
 
         // Make sure we're not out of bounds
-        assert(start >= 0 && start < _frameSize);
-        assert(end >=0 && end < _frameSize)
-        assert(color[0] >= 0 && color[0] <= 255);
-        assert(color[1] >= 0 && color[1] <= 255);
-        assert(color[2] >= 0 && color[2] <= 255);
+        start = _checkRange(start);
+        end = _checkRange(end);
+        color = _checkColorRange(color);
 
         // Flip start & end if required
         if (start > end) {
@@ -121,6 +117,7 @@ class WS2812 {
         }
 
         // Create a blob for the color
+        // Red and green are swapped for some reason, so swizzle them back
         local colorBlob = blob(BYTES_PER_PIXEL);
         colorBlob.writeblob(_bits[color[1]]);
         colorBlob.writeblob(_bits[color[0]]);
@@ -141,5 +138,19 @@ class WS2812 {
     function draw() {
         _spi.write(_frame);
         return this;
+    }
+
+    function _checkRange(index) {
+        if (index < 0) index = 0;
+        if (index >= _frameSize) index = _frameSize - 1;
+        return index;
+    }
+
+    function _checkColorRange(colors) {
+        foreach(idx, color in colors) {
+            if (color < 0) colors[idx] = 0;
+            if (color > 255) colors[idx] = 255;
+        }
+        return colors
     }
 }

--- a/examples/neoweather/neoweather.device.nut
+++ b/examples/neoweather/neoweather.device.nut
@@ -1,4 +1,4 @@
-#require "ws2812.class.nut:2.0.1"
+#require "ws2812.class.nut:2.0.2"
 
 class NeoWeather extends WS2812 {
 


### PR DESCRIPTION
Removed asserts that throw errors when out of range values passed into set() and fill().
Out of range values now adjusted to closest accepted values. 
