### PR TITLE
Lazily cache _bits array

### DIFF
--- a/WS2812.class.nut
+++ b/WS2812.class.nut
@@ -4,7 +4,7 @@
 
 class WS2812 {
 
-    static VERSION = "3.0.0";
+    static VERSION = "3.0.1";
 
     static ERROR_005 = "Use of this imp module is not advisable.";
 
@@ -37,6 +37,7 @@ class WS2812 {
     _frameSize       = null;  // number of pixels per frame
     _frame           = null;  // a blob to hold the current frame
     _bytes_per_pixel = null; // number of bytes per pixel
+    _makeBitPattern  = null; // (strategy)
 
     // Parameters:
     //    spi          A SPI bus
@@ -45,16 +46,15 @@ class WS2812 {
     constructor(spiBus, frameSize, _draw = true) {
         local impType = _getImpType();
         _configureSPI(spiBus, impType);
+        if (impType == 3) {
+            _makeBitPattern = _makeBitPattern003;
+        } else {
+            _makeBitPattern = _makeBitPatternDefault;
+        }
 
         _frameSize = frameSize;
         _frame = blob(_frameSize * _bytes_per_pixel + 1);
         _frame[_frameSize * _bytes_per_pixel] = 0;
-
-        // Used in constructing the _bits array
-        local bytesPerColor = _bytes_per_pixel / 3;
-
-        // (Multiple instance of WS2812 will only initialize it once)
-         if (_bits[0] == null) _fillBitsArray(impType, bytesPerColor);
 
         // Clear the pixel buffer
         fill([0,0,0]);
@@ -78,9 +78,9 @@ class WS2812 {
 
         // Create a blob for the color
         // Red and green are swapped for some reason, so swizzle them back
-        _frame.writeblob(_bits[color[1]]);
-        _frame.writeblob(_bits[color[0]]);
-        _frame.writeblob(_bits[color[2]]);
+        _frame.writeblob(_getBitPattern(color[1]));
+        _frame.writeblob(_getBitPattern(color[0]));
+        _frame.writeblob(_getBitPattern(color[2]));
 
         return this;
     }
@@ -109,9 +109,9 @@ class WS2812 {
         // Create a blob for the color
         // Red and green are swapped for some reason, so swizzle them back
         local colorBlob = blob(_bytes_per_pixel);
-        colorBlob.writeblob(_bits[color[1]]);
-        colorBlob.writeblob(_bits[color[0]]);
-        colorBlob.writeblob(_bits[color[2]]);
+        colorBlob.writeblob(_getBitPattern(color[1]));
+        colorBlob.writeblob(_getBitPattern(color[0]));
+        colorBlob.writeblob(_getBitPattern(color[2]));
 
         // Write the color blob to each pixel in the fill
         _frame.seek(start*_bytes_per_pixel);
@@ -185,30 +185,37 @@ class WS2812 {
         }
     }
 
-   function _fillBitsArray(impType, bytesPerColor) {
-        if (impType == 3) {
-            for (local i = 0; i < 256; i++) {
-                local valblob = blob(bytesPerColor);
-                valblob.writestring(_getNumber((i /64) % 4));
-                valblob.writestring(_getNumber((i /16) % 4));
-                valblob.writestring(_getNumber((i /4) % 4));
-                valblob.writestring(_getNumber(i % 4));
-                _bits[i] = valblob;
-            }
-        } else {
-            for (local i = 0; i < 256; i++) {
-                local valblob = blob(bytesPerColor);
-                valblob.writen((i & 0x80) ? ONE:ZERO,'b');
-                valblob.writen((i & 0x40) ? ONE:ZERO,'b');
-                valblob.writen((i & 0x20) ? ONE:ZERO,'b');
-                valblob.writen((i & 0x10) ? ONE:ZERO,'b');
-                valblob.writen((i & 0x08) ? ONE:ZERO,'b');
-                valblob.writen((i & 0x04) ? ONE:ZERO,'b');
-                valblob.writen((i & 0x02) ? ONE:ZERO,'b');
-                valblob.writen((i & 0x01) ? ONE:ZERO,'b');
-                _bits[i] = valblob;
-            }
+    function _getBitPattern(i) {
+        if (_bits[i] != null) {
+            return _bits[i];
         }
+
+        _bits[i] = _makeBitPattern(i);
+        return _bits[i];
+    }
+
+    function _makeBitPattern003(i) {
+        local bytesPerColor = _bytes_per_pixel / 3;
+        local valblob = blob(bytesPerColor);
+        valblob.writestring(_getNumber((i /64) % 4));
+        valblob.writestring(_getNumber((i /16) % 4));
+        valblob.writestring(_getNumber((i /4) % 4));
+        valblob.writestring(_getNumber(i % 4));
+        return valblob;
+    }
+
+    function _makeBitPatternDefault(i) {
+        local bytesPerColor = _bytes_per_pixel / 3;
+        local valblob = blob(bytesPerColor);
+        valblob.writen((i & 0x80) ? ONE:ZERO,'b');
+        valblob.writen((i & 0x40) ? ONE:ZERO,'b');
+        valblob.writen((i & 0x20) ? ONE:ZERO,'b');
+        valblob.writen((i & 0x10) ? ONE:ZERO,'b');
+        valblob.writen((i & 0x08) ? ONE:ZERO,'b');
+        valblob.writen((i & 0x04) ? ONE:ZERO,'b');
+        valblob.writen((i & 0x02) ? ONE:ZERO,'b');
+        valblob.writen((i & 0x01) ? ONE:ZERO,'b');
+        return valblob;
     }
 
     function _getNumber(num) {


### PR DESCRIPTION
The '_bits' array uses ~24KB of memory, which seems excessive.

*Not* caching bit patterns is an unacceptable performance hit, so
convert it to a lazy cache, rather than an eager one.

Also use the strategy pattern to hide the imp003/impXXX difference in
the bit pattern generation.